### PR TITLE
per_page defaults on region

### DIFF
--- a/app/Http/Controllers/BarangayController.php
+++ b/app/Http/Controllers/BarangayController.php
@@ -16,7 +16,7 @@ class BarangayController extends Controller
      */
     public function index(Request $request)
     {
-        $perPage = $request->per_page ?? self::ITEMS_PER_PAGE;
+        $perPage = $request->per_page ?? static::ITEMS_PER_PAGE;
 
         $barangays = QueryBuilder::for(Barangay::class);
 

--- a/app/Http/Controllers/CityController.php
+++ b/app/Http/Controllers/CityController.php
@@ -16,7 +16,7 @@ class CityController extends Controller
      */
     public function index(Request $request)
     {
-        $perPage = $request->per_page ?? self::ITEMS_PER_PAGE;
+        $perPage = $request->per_page ?? static::ITEMS_PER_PAGE;
 
         $cities = QueryBuilder::for(City::class)->allowedIncludes('barangays', 'subMunicipalities');
 

--- a/app/Http/Controllers/DistrictController.php
+++ b/app/Http/Controllers/DistrictController.php
@@ -16,7 +16,7 @@ class DistrictController extends Controller
      */
     public function index(Request $request)
     {
-        $perPage = $request->per_page ?? self::ITEMS_PER_PAGE;
+        $perPage = $request->per_page ?? static::ITEMS_PER_PAGE;
 
         $districts = QueryBuilder::for(District::class)->allowedIncludes('cities');
 

--- a/app/Http/Controllers/MunicipalityController.php
+++ b/app/Http/Controllers/MunicipalityController.php
@@ -16,7 +16,7 @@ class MunicipalityController extends Controller
      */
     public function index(Request $request)
     {
-        $perPage = $request->per_page ?? self::ITEMS_PER_PAGE;
+        $perPage = $request->per_page ?? static::ITEMS_PER_PAGE;
 
         $municipalities = QueryBuilder::for(Municipality::class)->allowedIncludes('barangays');
 

--- a/app/Http/Controllers/ProvinceController.php
+++ b/app/Http/Controllers/ProvinceController.php
@@ -16,7 +16,7 @@ class ProvinceController extends Controller
      */
     public function index(Request $request)
     {
-        $perPage = $request->per_page ?? self::ITEMS_PER_PAGE;
+        $perPage = $request->per_page ?? static::ITEMS_PER_PAGE;
 
         $provinces = QueryBuilder::for(Province::class)->allowedIncludes('cities', 'municipalities');
 

--- a/app/Http/Controllers/RegionController.php
+++ b/app/Http/Controllers/RegionController.php
@@ -14,7 +14,7 @@ class RegionController extends Controller
     /**
      * Display a listing of the resource.
      *
-     * @param  Request  $request
+     * @param Request $request
      */
     public function index(Request $request)
     {
@@ -32,8 +32,8 @@ class RegionController extends Controller
     /**
      * Display the specified resource.
      *
-     * @param  Request  $request
-     * @param  Region  $region
+     * @param Request $request
+     * @param Region  $region
      */
     public function show(Request $request, Region $region)
     {

--- a/app/Http/Controllers/RegionController.php
+++ b/app/Http/Controllers/RegionController.php
@@ -9,14 +9,16 @@ use App\Http\Resources\RegionResource;
 
 class RegionController extends Controller
 {
+    const ITEMS_PER_PAGE = 'all';
+
     /**
      * Display a listing of the resource.
      *
-     * @param Request $request
+     * @param  Request  $request
      */
     public function index(Request $request)
     {
-        $perPage = $request->per_page ?? self::ITEMS_PER_PAGE;
+        $perPage = $request->per_page ?? static::ITEMS_PER_PAGE;
 
         $regions = QueryBuilder::for(Region::class)->allowedIncludes('provinces', 'districts');
 
@@ -30,8 +32,8 @@ class RegionController extends Controller
     /**
      * Display the specified resource.
      *
-     * @param Request $request
-     * @param Region  $region
+     * @param  Request  $request
+     * @param  Region  $region
      */
     public function show(Request $request, Region $region)
     {

--- a/app/Http/Controllers/SubMunicipalityController.php
+++ b/app/Http/Controllers/SubMunicipalityController.php
@@ -16,7 +16,7 @@ class SubMunicipalityController extends Controller
      */
     public function index(Request $request)
     {
-        $perPage = $request->per_page ?? self::ITEMS_PER_PAGE;
+        $perPage = $request->per_page ?? static::ITEMS_PER_PAGE;
 
         $subMunicipalities = QueryBuilder::for(SubMunicipality::class)->allowedIncludes('barangays');
 


### PR DESCRIPTION
Change the default for region to show the 17 regions instead of the inherited constant value of 15. This will show the all the top level results of the API (region) instead of having to pass `per_page=all` on initial query of the API. The change also allows to respect the const override on the child controllers.